### PR TITLE
Retool `wp precache core` to run before WP loads

### DIFF
--- a/features/precache-core.feature
+++ b/features/precache-core.feature
@@ -1,10 +1,12 @@
 Feature: Precache WordPress core
 
   Scenario: Precache core with a specific version
-    Given a WP install
+    Given an empty directory
 
     When I run `wp precache core --version=4.4.2`
     Then STDOUT should contain:
       """
-      Success: WordPress pre-cached.
+      Downloading WordPress 4.4.2 (en_US)...
+      md5 hash verified: 65d89263dad6154fdc8b747e9ef4e357
+      Success: WordPress pre-cached as core/wordpress-4.4.2-en_US.tar.gz
       """


### PR DESCRIPTION
This makes the feature independent of having an active WP install

Fixes #1, fixes #2
See #3
