### PR TITLE
Fix: make WP_CLI command registration compatible with PHP8

### DIFF
--- a/command.php
+++ b/command.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace runcommand\precache;
+use WP_CLI;
+
 require_once dirname( __FILE__ ) . '/inc/class-precache-command.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {


### PR DESCRIPTION
Hi, since the repo is not archived, I thought I would give it a try 🙂 

This PR adds support for PHP8 and maintains backwards compatibility with PHP7, would be great if this could be merged.

Without this change, most `wp-cli` commands fail with
```
PHP Fatal error:  Uncaught Error: Class "WP_CLI" not found in .../packages/vendor/runcommand/precache/command.php:6
```